### PR TITLE
Find the shortest contraction, with option to disable

### DIFF
--- a/SudokuSolverConsole/Program.cs
+++ b/SudokuSolverConsole/Program.cs
@@ -55,6 +55,7 @@ namespace SudokuSolverConsole
             string candidates = null;
             bool listen = false;
             string portStr = null;
+            bool disableFindShortestContradiction = false;
 
             var options = new OptionSet {
                 // Non-solve options
@@ -78,6 +79,7 @@ namespace SudokuSolverConsole
                 { "k|check", "Check if there are 0, 1, or 2+ solutions.", k => check = k != null },
                 { "n|solutioncount", "Provide an exact solution count.", n => solutionCount = n != null },
                 { "t|multithread", "Use multithreading.", t => multiThread = t != null },
+                { "e|dontfindshortestcontradiction", "Don't find the shortest contradiction.", e => disableFindShortestContradiction = e!=null },
 
                 // Post-solve options
                 { "o|out=", "Output solution(s) to file.", o => outputPath = o },
@@ -215,6 +217,8 @@ namespace SudokuSolverConsole
                 Console.WriteLine(e.Message);
                 return;
             }
+
+            solver.DisableFindShortestContradiction = disableFindShortestContradiction;
 
             if (print)
             {


### PR DESCRIPTION
The solver will now try to find the shortest contradiction instead of taking the first available.

This leads to more "logical" logical solves, and may, but not always, leads to shorter solves.

This will take a little more time, especially so on larger grids. So there is a new command-line option `-e` in place to disable this.