### PR TITLE
Implement the -contradictionlimit option

### DIFF
--- a/SudokuSolver/Solver.cs
+++ b/SudokuSolver/Solver.cs
@@ -58,6 +58,7 @@ namespace SudokuSolver
         public bool DisableWings { get; set; } = false;
         public bool DisableContradictions { get; set; } = false;
         public bool DisableFindShortestContradiction { get; set; } = false;
+        public uint? ContradictionStepCountLimit { get; set; } = null;
 
         private uint[,] board;
         private int[,] regions = null;
@@ -274,6 +275,7 @@ namespace SudokuSolver
             DisableWings = other.DisableWings;
             DisableContradictions = other.DisableContradictions;
             DisableFindShortestContradiction = other.DisableFindShortestContradiction;
+            ContradictionStepCountLimit = other.ContradictionStepCountLimit;
             board = (uint[,])other.board.Clone();
             regions = other.regions;
             seenMap = other.seenMap;
@@ -3141,7 +3143,8 @@ namespace SudokuSolver
                                         if (!DisableContradictions)
                                         {
                                             int changes = boardCopy.AmountCellsFilled() - this.AmountCellsFilled();
-                                            if (bestContradiction == null || changes < bestContradiction.Changes)
+                                            // Plus one here since we don't count the cell without candidates as "step", but the AmountCellsFilled method does
+                                            if (changes <= (ContradictionStepCountLimit + 1) && (bestContradiction == null || changes < bestContradiction.Changes))
                                             {
                                                 bestContradiction = new ContradictionResult(changes, boardCopy, i, j, v, formattedContraditionReason);
                                             }
@@ -3154,7 +3157,7 @@ namespace SudokuSolver
                 }
                 if (bestContradiction != null)
                 {
-                    stepDescription?.Append($"Setting {CellName(bestContradiction.I, bestContradiction.J)} to {bestContradiction.V} causes a contradiction:")
+                    stepDescription?.Append($"Setting {CellName(bestContradiction.I, bestContradiction.J)} to {bestContradiction.V} causes a contradiction ({bestContradiction.Changes} cells filled before contradiction was detected):")
                                     .AppendLine()
                                     .Append(bestContradiction.FormattedContraditionReason);
 

--- a/SudokuSolver/Solver.cs
+++ b/SudokuSolver/Solver.cs
@@ -3157,7 +3157,7 @@ namespace SudokuSolver
                 }
                 if (bestContradiction != null)
                 {
-                    stepDescription?.Append($"Setting {CellName(bestContradiction.I, bestContradiction.J)} to {bestContradiction.V} causes a contradiction ({bestContradiction.Changes} cells filled before contradiction was detected):")
+                    stepDescription?.Append($"Setting {CellName(bestContradiction.I, bestContradiction.J)} to {bestContradiction.V} causes a contradiction:")
                                     .AppendLine()
                                     .Append(bestContradiction.FormattedContraditionReason);
 

--- a/SudokuSolverConsole/Program.cs
+++ b/SudokuSolverConsole/Program.cs
@@ -43,6 +43,7 @@ namespace SudokuSolverConsole
             string outputPath = null;
             List<string> constraints = new();
             bool multiThread = false;
+            uint? contradictionStepCountLimit = null;
             bool solveBruteForce = false;
             bool solveRandomBruteForce = false;
             bool solveLogically = false;
@@ -79,6 +80,7 @@ namespace SudokuSolverConsole
                 { "k|check", "Check if there are 0, 1, or 2+ solutions.", k => check = k != null },
                 { "n|solutioncount", "Provide an exact solution count.", n => solutionCount = n != null },
                 { "t|multithread", "Use multithreading.", t => multiThread = t != null },
+                { "cl|contradictionlimit=", "Largest amount of steps a contradiction may take.",  l => contradictionStepCountLimit = uint.Parse(l)},
 
                 // Post-solve options
                 { "o|out=", "Output solution(s) to file.", o => outputPath = o },
@@ -217,6 +219,7 @@ namespace SudokuSolverConsole
                 return;
             }
 
+            solver.ContradictionStepCountLimit = contradictionStepCountLimit;
             if (print)
             {
                 Console.WriteLine("Input puzzle:");


### PR DESCRIPTION
Users can now use `-cl=number` or `-contradictionlimit=number` to limit how deep the solver searches for contradictions.

This is a naive implementation that only checks _after_ a contradiction is found how long it is.

A possible improvement is to pass this into the solver and actually stop once a certain depth is reached. The solver is luckily quite fast so that is not needed at this point.