### PR TITLE
Improve ArrowSumConstraint's handling of grids > 9*9

### DIFF
--- a/SudokuSolver/Constraints/ArrowSumConstraint.cs
+++ b/SudokuSolver/Constraints/ArrowSumConstraint.cs
@@ -519,14 +519,20 @@ namespace SudokuSolver.Constraints
             if(cells > 1)
             {
                 // Max digits per cell is TotalDigits - (CircleCells - 1)
-                for (var take = 1; take <= total.Length() - (cells - 1); take++)
+                for (var numberDigits = 1; numberDigits <= total.Length() - (cells - 1); numberDigits++)
                 {
-                    var first = total.SubInt(0, take);
+                    var first = total.Take(numberDigits);
 
                     // We can't continue if first is now > max
                     if (first > maxValue) yield break;
 
-                    var remaining = total.SubInt(take, total.Length() - take);
+                    var remaining = total.Skip(numberDigits, out int leadingZeros);
+
+                    if(leadingZeros > 0)
+                    {
+                        // If we took these digits, the remaining digits would have a leading 0!
+                        continue;
+                    }
 
                     foreach(var remainingCombination in PossibleCircleArrangements(remaining, cells - 1, maxValue))
                     {

--- a/SudokuSolver/Extensions.cs
+++ b/SudokuSolver/Extensions.cs
@@ -101,39 +101,63 @@ namespace SudokuSolver
             return list;
         }
 
-        public static int SubInt(this int target, int startIndex, int length)
+        private static readonly int[] POWERS_OF_10 = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
+
+        public static int SubInt(this int subject, int startIndex, int length, out int leadingZeros)
         {
-            var targetLength = target.Length();
+            var subjectLength = subject.Length();
+            var final = subject;
 
             // Constrain length += startIndex to be <= target.Length()
-            if(startIndex + length > targetLength)
+            if (startIndex + length > subjectLength)
             {
-                length += (targetLength - startIndex - length);
+                length += (subjectLength - startIndex - length);
             }
 
-            // Obviously slower... Figure out the skipped digits and subtract from target
-            if(startIndex > 0)
+            var zeros = 0;
+
+            if (startIndex > 0)
             {
-                target -= target.SubInt(0, startIndex) * (int)Math.Pow(10, targetLength - startIndex);
+                final -= (subject / POWERS_OF_10[subjectLength - startIndex]) * POWERS_OF_10[subjectLength - startIndex];
+
+                // We might have exposed 1 or more leading 0s.
+                zeros = (subjectLength - startIndex) - final.Length();
             }
 
-            return target / (int)Math.Pow(10, target.Length() - length);
+            // Let the called know if any "characters" have been dropped due to leading zeros.
+            leadingZeros = zeros;
+
+            // If our final number is 0 then return now to avoid / 0 error
+            return final == 0 ? 0 : final / POWERS_OF_10[final.Length() - (length - zeros)];
+        }
+
+        public static int Take(this int subject, int numberDigits)
+        {
+            return subject.SubInt(0, numberDigits, out int ignore);
+        }
+
+        public static int Skip(this int subject, int numberToSkip, out int leadingZeros)
+        {
+            return subject.SubInt(numberToSkip, subject.Length() - numberToSkip, out leadingZeros);
         }
 
         public static int Length(this int target)
         {
-            if (target < 10)
-                return 1;
-            else if (target < 100)
-                return 2;
-            else if (target < 1000)
-                return 3;
-            else if (target < 10000)
-                return 4;
-            else if (target < 100000)
-                return 5;
-            else
-                throw new ApplicationException(String.Format("I never imagined there were numbers as large as {0}!", target));
+            if(target < 0) 
+            {
+                target = Math.Abs(target);
+            }
+
+            if (target < 10)                { return 1; }
+            else if (target < 100)          { return 2; }
+            else if (target < 1000)         { return 3; }
+            else if (target < 10000)        { return 4; }
+            else if (target < 100000)       { return 5; }
+            else if (target < 1000000)      { return 6; }
+            else if (target < 10000000)     { return 7; }
+            else if (target < 100000000)    { return 8; }
+            else if (target < 1000000000)   { return 9; }
+            else                            { return 10; }  // Int32.Max = 10
         }
     }
 }

--- a/SudokuTests/ArrowTests.cs
+++ b/SudokuTests/ArrowTests.cs
@@ -364,50 +364,7 @@ namespace SudokuTests
 
         #endregion
 
-        [TestMethod]
-        public void IntLengthIsNumberOfCharacters()
-        {
-            var skip = 1;
-
-            for(var i = 0; i < 100000; i += skip)
-            {
-                Assert.AreEqual(i.ToString().Length, i.Length());
-
-                skip *= 10;
-            }
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ApplicationException))]
-        public void ThereAreLimits()
-        {
-            100000.Length();
-        }
-
-        [TestMethod]
-        public void FirstXDigits()
-        {
-            Assert.AreEqual(123, 1234.SubInt(0, 3));
-        }
-
-        [TestMethod]
-        public void LastXDigits()
-        {
-            Assert.AreEqual(234, 1234.SubInt(1, 3));
-        }
-
-        [TestMethod]
-        public void LengthGreaterThanDigitsReturnsRest()
-        {
-            Assert.AreEqual(2345, 12345.SubInt(1, 10));
-            Assert.AreEqual(12345, 12345.SubInt(0, 100));
-        }
-
-        [TestMethod]
-        public void RealCase()
-        {
-            Assert.AreEqual(5, 115.SubInt(2, 1));
-        }
+        
 
         private void TestLogic(String options, int gridSize, LogicResult expectedResult, String messageContains, Action<Solver> setup, Action<Solver> after = null)
         {

--- a/SudokuTests/ExtensionTests.cs
+++ b/SudokuTests/ExtensionTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SudokuSolver;
+
+namespace SudokuTests
+{
+    [TestClass]
+    public class ExtensionTests
+    {
+        [TestMethod]
+        public void IntLengthIsNumberOfCharacters()
+        {
+            var skip = 1;
+
+            for (var i = 0; i < 100000; i += skip)
+            {
+                Assert.AreEqual(i.ToString().Length, i.Length());
+
+                skip *= 10;
+            }
+        }
+
+        [TestMethod]
+        public void FirstXDigits()
+        {
+            Assert.AreEqual(123, 1234.SubInt(0, 3, out int leadingZeros));
+            Assert.AreEqual(0, leadingZeros);
+        }
+
+        [TestMethod]
+        public void LastXDigits()
+        {
+            Assert.AreEqual(234, 1234.SubInt(1, 3, out int leadingZeros));
+            Assert.AreEqual(0, leadingZeros);
+        }
+
+        [TestMethod]
+        public void LengthGreaterThanDigitsReturnsRest()
+        {
+            int leadingZeros = 0;
+
+            Assert.AreEqual(2345, 12345.SubInt(1, 10, out leadingZeros));
+            Assert.AreEqual(12345, 12345.SubInt(0, 100, out leadingZeros));
+        }
+
+        [TestMethod]
+        public void RealCase()
+        {
+            Assert.AreEqual(5, 115.SubInt(2, 1, out int leadingZeros));
+            Assert.AreEqual(0, leadingZeros);
+        }
+
+        [TestMethod]
+        public void LeadingZero()
+        {
+            Assert.AreEqual(24, 1024.SubInt(1, 3, out int leadingZeros));
+            Assert.AreEqual(1, leadingZeros);
+        }
+
+        [TestMethod]
+        public void WorksForLargeInts()
+        {
+            Assert.AreEqual(10, Int32.MaxValue.Length());
+        }
+
+        [TestMethod]
+        public void ZeroIsOneDigit()
+        {
+            Assert.AreEqual(1, 0.Length());
+        }
+
+        [TestMethod]
+        public void SubstringZero()
+        {
+            Assert.AreEqual(0, 1000.SubInt(1, 3, out int leadingZeros));
+
+            // 2 leading 0s ahead of the last 0 which is represented in the return value
+            Assert.AreEqual(2, leadingZeros);
+        }
+
+        [TestMethod]
+        public void LengthWorksForNegatives()
+        {
+            Assert.AreEqual(3, (-123).Length());
+        }
+
+        [TestMethod]
+        public void TakeIsSubInt0()
+        {
+            Assert.AreEqual(12345.SubInt(0, 3, out int leading), 12345.Take(3));
+        }
+
+        [TestMethod]
+        public void SkipIsRestOfDigits()
+        {
+            Assert.AreEqual(12045.SubInt(2, 3, out int leading1), 12045.Skip(2, out int leading2));
+            Assert.AreEqual(leading1, leading2);
+            Assert.AreEqual(1, leading1);
+        }
+
+        [TestMethod]
+        public void ChainingWorks()
+        {
+            Assert.AreEqual(123, 567123.Skip(3, out int leading).Take(3));
+        }
+
+        [TestMethod]
+        public void TakeWorksForNegatives()
+        {
+            Assert.AreEqual(-123, -12345.Take(3));
+        }
+
+        [TestMethod]
+        public void SkipWorksForNegatives()
+        {
+            Assert.AreEqual(-45, -12345.Skip(3, out int leading));
+        }
+
+        [TestMethod]
+        public void LeadingZerosWorkForNegatives()
+        {
+            Assert.AreEqual(-45, -123045.Skip(3, out int leading));
+            Assert.AreEqual(1, leading);
+        }
+    }
+}


### PR DESCRIPTION
I've updated ArrowSumConstraint's handling of large grid sizes, especially where pills are involved. This includes handling the ambiguous situation when a pill contains the total 115 which could be represented with 11, 5 or 1, 15. Closes #62  

The main thrust of the change is the new PossibleCircleArrangements method which returns all the ways to arrange a total in a given number of cells with a specified max value. That's then combined with ValidCircleArrangements to check which arrangements are actually allowed based on the current candidates.

I've tried to surround everything I've done with unit tests which I've put in the existing project. All the new + existing tests are currently passing.

There's still lots of room for improvement but I've tried to limit the scope to resolving obvious issues with large grid sizes. Let me know if you need me to improve anything.

