### PR TITLE
Support of additional constraints read from f-puzzles' rules text 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,17 @@
 			// Use IntelliSense to find out which attributes exist for C# debugging
 			// Use hover for the description of the existing attributes
 			// For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-			"name": ".NET Core Launch (console)",
+			"name": "Debug f-puzzles listener",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build",
 			// If you have changed target frameworks, make sure to update the program path.
-			"program": "${workspaceFolder}/SudokuSolverConsole/bin/Debug/net5.0/SudokuSolverConsole.dll",
-			"args": [],
+			"program": "${workspaceFolder}/SudokuSolverConsole/bin/Debug/net6.0/SudokuSolverConsole.dll",
+			"args": ["--listen"],
 			"cwd": "${workspaceFolder}/SudokuSolverConsole",
 			// For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
-			"console": "internalConsole",
+			// set to integratedTerminal to allow for command line interactions during tuntime 
+			"console": "integratedTerminal",
 			"stopAtEntry": false
 		},
 		{

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,11 @@
 				"/property:GenerateFullPaths=true",
 				"/consoleloggerparameters:NoSummary"
 			],
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
 		},
 		{
 			"label": "publish",
@@ -32,11 +36,25 @@
 			"args": [
 				"watch",
 				"run",
+				"--project",
 				"${workspaceFolder}/SudokuSolverConsole/SudokuSolverConsole.csproj",
-				"/property:GenerateFullPaths=true",
 				"/consoleloggerparameters:NoSummary"
 			],
 			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "test",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"test",
+				"${workspaceFolder}/SudokuTests/SudokuTests.csproj"
+			],
+			"problemMatcher": "$msCompile",
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			}
 		}
 	]
 }

--- a/SudokuSolver/SolverFactory.cs
+++ b/SudokuSolver/SolverFactory.cs
@@ -239,7 +239,7 @@ namespace SudokuSolver
             string fpuzzlesJson = LZString.DecompressFromBase64(fpuzzlesURL);
             var fpuzzlesData = JsonSerializer.Deserialize(fpuzzlesJson, FpuzzlesJsonContext.Default.FPuzzlesBoard);
 
-            // Set the default regions
+         // Set the default regions
             int i, j;
             int height = fpuzzlesData.grid.Length;
             int width = fpuzzlesData.grid[0].Length;
@@ -295,6 +295,11 @@ namespace SudokuSolver
                 Author = fpuzzlesData.author,
                 Rules = fpuzzlesData.ruleset
             };
+            string[] constraintsFromRules = fpuzzlesData.ruleset.Split("constraints:");
+            if (constraintsFromRules.Length == 2) ApplyConstraints(solver, 
+                Array.FindAll(constraintsFromRules[1].Split(), c => !string.IsNullOrWhiteSpace(c))
+            );   
+            
             uint disabledLogicFlags = 0;
             if (fpuzzlesData.disabledlogic != null)
             {


### PR DESCRIPTION
By adding `constraints: <contraint args>` the args are considered by the solver. Example:
```
Regular Sudoku rules and Anti-Camel rules apply (some arbitrary text)

constraints: chess:1,3 
```

There are also some changes to allow testing and debugging with VSCode