### PR TITLE
Fix gear icon when user script is imported as ASCII

### DIFF
--- a/UserScripts/Fpuzzles-SudokuSolver.user.js
+++ b/UserScripts/Fpuzzles-SudokuSolver.user.js
@@ -17,7 +17,7 @@
     const doShim = function() {
         // Makes center and corner marks larger so they're easier to see.
         let textScale = 1.5;
-        const settingsIcon = '⚙️';
+        const settingsIcon = '\u2699\uFE0F';
 
         const connectButtonOffset = 208;
         const connectButton = new button(canvas.width - connectButtonOffset, 40, 215, 40, ['Setting', 'Solving'], 'Connect', 'Connect');


### PR DESCRIPTION
If the script is imported as ASCII instead of UTF-8, then the gear icon will be all messed up.
This replaces the emoji with the matching sequence in UTF-16 code units to always make it work.