### PR TITLE
Entropic Lines: Fix issue with conflict detection

### DIFF
--- a/UserScripts/fpuzzles-newconstraints.js
+++ b/UserScripts/fpuzzles-newconstraints.js
@@ -543,17 +543,23 @@
                                 }
                             }
 
-                            for (let index = 0; index < line.length; index++) {
-                                if (line[index].value) {
-                                    for (let i = 0; i < entropicLineGroups.length; i++) {
-                                        if (entropicLineGroups[i].includes(line[index].value)) {
-                                            if (lineGroupIndices[i] === -1) {
-                                                lineGroupIndices[i] = index % 3;
+                            for (let i = 0; i < line.length; i++) {
+                                if (line[i].value) {
+                                    for (let j = 0; j < entropicLineGroups.length; j++) {
+                                        if (entropicLineGroups[j].includes(line[i].value)) {
+                                            if (lineGroupIndices[j] === -1) {
+                                                lineGroupIndices[j] = i % 3;
+                                            }
+                                            else if (lineGroupIndices[j] !== i % 3) {
+                                                if (index % 3 === i % 3 || lineGroupIndices[j] === index % 3) {
+                                                    return false;
+                                                }  
                                             }
                                         }
                                     }
                                 }
                             }
+
 
                             if (lineGroupIndices[nGroup] !== -1) {
                                 if (lineGroupIndices[nGroup] !== (index % 3)) {

--- a/UserScripts/fpuzzles-newconstraints.js
+++ b/UserScripts/fpuzzles-newconstraints.js
@@ -547,7 +547,9 @@
                                 if (line[index].value) {
                                     for (let i = 0; i < entropicLineGroups.length; i++) {
                                         if (entropicLineGroups[i].includes(line[index].value)) {
-                                            lineGroupIndices[i] = index % 3;
+                                            if (lineGroupIndices[i] === -1) {
+                                                lineGroupIndices[i] = index % 3;
+                                            }
                                         }
                                     }
                                 }
@@ -556,7 +558,7 @@
                             if (lineGroupIndices[nGroup] !== -1) {
                                 if (lineGroupIndices[nGroup] !== (index % 3)) {
                                     return false;
-                                } else if (lineGroupIndices[index % 3] !== -1 && !entropicLineGroups[lineGroupIndices[index % 3]].includes(n)) {
+                                } else if (lineGroupIndices.indexOf(index % 3) !== -1 && lineGroupIndices.indexOf(index % 3) !== nGroup) {
                                     return false;
                                 }
                             } else if (lineGroupIndices[(nGroup + 1) % 3] !== -1 && lineGroupIndices[(nGroup + 2) % 3] !== -1) {


### PR DESCRIPTION
Previously the array lineGroupIndices was being indexed with a line
index rather than a group. This caused the conflict detection to get
confused an mark things wrong that are perfectly legal.

Fixes issue #96 