### PR TITLE
Grid inheritance optimization

### DIFF
--- a/SudokuSolver/Constraints/Constraint.cs
+++ b/SudokuSolver/Constraints/Constraint.cs
@@ -37,6 +37,12 @@ public abstract class Constraint
     public virtual string GetHash(Solver solver) => string.IsNullOrWhiteSpace(OPTIONS) ? "" : OPTIONS;
 
     /// <summary>
+    /// Split the constraint to a set of smaller constraints that are together identical to the current one.
+    /// </summary>
+    /// <returns>A set of elementary constraints that represent the current constraint when united.</returns>
+    public virtual IEnumerable<Constraint> SplitToPrimitives(Solver sudokuSolver) => new Constraint[] { this };
+
+    /// <summary>
     /// Return an enumerable of cells which cannot be the same digit as this cell.
     /// Only need to return cells which wouldn't be seen by normal sudoku rules.
     /// Also no need to return any cells if the Group property is used.

--- a/SudokuSolver/Constraints/DifferenceConstraint.cs
+++ b/SudokuSolver/Constraints/DifferenceConstraint.cs
@@ -7,6 +7,14 @@ public class DifferenceConstraint : OrthogonalValueConstraint
     {
     }
 
+    public DifferenceConstraint(Solver sudokuSolver, int negativeConstraintValue) : base(sudokuSolver, negativeConstraintValue)
+    {
+    }
+
+    public DifferenceConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2) : base(sudokuSolver, markerValue, cell1, cell2)
+    {
+    }
+
     protected override bool IsPairAllowedAcrossMarker(int markerValue, int v0, int v1) => (v0 + markerValue == v1 || v1 + markerValue == v0);
 
     protected override IEnumerable<OrthogonalValueConstraint> GetRelatedConstraints(Solver solver) =>

--- a/SudokuSolver/Constraints/EntropicLineConstraint.cs
+++ b/SudokuSolver/Constraints/EntropicLineConstraint.cs
@@ -31,6 +31,12 @@ public class EntropicLineConstraint : Constraint
         cellsSet = new(cells);
     }
 
+    public EntropicLineConstraint(Solver sudokuSolver, IEnumerable<(int, int)> cells) : base(sudokuSolver, cells.CellNames(""))
+    {
+        this.cells = cells.ToList();
+        cellsSet = new(cells);
+    }
+
     public override string SpecificName => $"Entropic Line {CellName(cells[0])} - {CellName(cells[^1])}";
 
     private int getCellGroup(uint cellMask) {
@@ -488,6 +494,27 @@ public class EntropicLineConstraint : Constraint
         }
 
         return hadChange ? LogicResult.Changed : LogicResult.None;
+    }
+
+    public override IEnumerable<Constraint> SplitToPrimitives(Solver sudokuSolver)
+    {
+        if (cells.Count < 3)
+        {
+            return base.SplitToPrimitives(sudokuSolver);
+        }
+
+        List<EntropicLineConstraint> constraints = new(cells.Count - 2);
+        for (int i = 0; i < cells.Count - 2; i++)
+        {
+            List<(int, int)> cellsTriple = new() { cells[i], cells[i + 1], cells[i + 2] };
+            // Ensure that the lines have consistent order
+            if (cellsTriple[0].CompareTo(cellsTriple[2]) > 0)
+            {
+                cellsTriple.Reverse();
+            }
+            constraints.Add(new(sudokuSolver, cellsTriple));
+        }
+        return constraints;
     }
 
 }

--- a/SudokuSolver/Constraints/OrthogonalValueConstraint.cs
+++ b/SudokuSolver/Constraints/OrthogonalValueConstraint.cs
@@ -37,7 +37,14 @@ public abstract class OrthogonalValueConstraint : Constraint
         // Include the negative constraint area "holes" in the hash
         if (negativeConstraint)
         {
-            var overrideMarkers = GetRelatedConstraints(solver).SelectMany(x => x.Markers.Keys).ToHashSet().ToSortedList();
+            // The current constraint type could be represented by more than 1 object,
+            // so concatenate results of the regular GetRelatedConstraints() implementation
+            // with all constraints of the same type
+            // to get the full list of constraints that may affect the set of ignored pairs for the negative constraint
+            var relatedConstraints = solver.Constraints<OrthogonalValueConstraint>()
+                .Where(constraint => constraint.GetType() == GetType())
+                .Concat(GetRelatedConstraints(solver));
+            var overrideMarkers = relatedConstraints.SelectMany(x => x.Markers.Keys).ToHashSet().ToSortedList();
             if (overrideMarkers.Count > 0)
             {
                 result.Append("-");

--- a/SudokuSolver/Constraints/RatioConstraint.cs
+++ b/SudokuSolver/Constraints/RatioConstraint.cs
@@ -7,6 +7,14 @@ public class RatioConstraint : OrthogonalValueConstraint
     {
     }
 
+    public RatioConstraint(Solver sudokuSolver, int negativeConstraintValue) : base(sudokuSolver, negativeConstraintValue)
+    {
+    }
+
+    public RatioConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2) : base(sudokuSolver, markerValue, cell1, cell2)
+    {
+    }
+
     protected override bool IsPairAllowedAcrossMarker(int markerValue, int v0, int v1) => (v0 * markerValue == v1 || v1 * markerValue == v0);
 
     protected override IEnumerable<OrthogonalValueConstraint> GetRelatedConstraints(Solver solver) =>

--- a/SudokuSolver/Constraints/SumConstraint.cs
+++ b/SudokuSolver/Constraints/SumConstraint.cs
@@ -7,6 +7,14 @@ public class SumConstraint : OrthogonalValueConstraint
     {
     }
 
+    public SumConstraint(Solver sudokuSolver, int negativeConstraintValue) : base(sudokuSolver, negativeConstraintValue)
+    {
+    }
+
+    public SumConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2) : base(sudokuSolver, markerValue, cell1, cell2)
+    {
+    }
+
     protected override bool IsPairAllowedAcrossMarker(int markerValue, int v0, int v1) => (v0 + v1 == markerValue);
 
     protected override int DefaultMarkerValue => 5;

--- a/SudokuSolver/Constraints/ThermometerConstraint.cs
+++ b/SudokuSolver/Constraints/ThermometerConstraint.cs
@@ -20,6 +20,12 @@ public class ThermometerConstraint : Constraint
         cellsSet = new(cells);
     }
 
+    public ThermometerConstraint(Solver sudokuSolver, IEnumerable<(int, int)> cells) : base(sudokuSolver, cells.CellNames(""))
+    {
+        this.cells = cells.ToList();
+        cellsSet = new(cells);
+    }
+
     public override string SpecificName => $"Thermometer {CellName(cells[0])} - {CellName(cells[^1])}";
 
     public override LogicResult InitCandidates(Solver sudokuSolver)
@@ -181,5 +187,15 @@ public class ThermometerConstraint : Constraint
     }
 
     public override List<(int, int)> Group => cells;
+
+    public override IEnumerable<Constraint> SplitToPrimitives(Solver sudokuSolver)
+    {
+        List<ThermometerConstraint> constraints = new(cells.Count - 1);
+        for (int i = 0; i < cells.Count - 1; i++)
+        {
+            constraints.Add(new(sudokuSolver, new (int, int)[] { cells[i], cells[i + 1] }));
+        }
+        return constraints;
+    }
 }
 

--- a/SudokuSolver/Constraints/WhispersConstraint.cs
+++ b/SudokuSolver/Constraints/WhispersConstraint.cs
@@ -39,6 +39,13 @@ public class WhispersConstraint : Constraint
         cellsSet = new(cells);
     }
 
+    public WhispersConstraint(Solver sudokuSolver, IEnumerable<(int, int)> cells, int difference) : base(sudokuSolver, difference + ";" + cells.CellNames(""))
+    {
+        this.difference = difference;
+        this.cells = cells.ToList();
+        cellsSet = new(cells);
+    }
+
     public override string SpecificName => $"Whispers {CellName(cells[0])} - {CellName(cells[^1])}";
 
     public override LogicResult InitCandidates(Solver sudokuSolver)
@@ -261,6 +268,18 @@ public class WhispersConstraint : Constraint
             keepMask |= MaskValAndHigher(minLargeVal);
         }
         return keepMask;
+    }
+
+    public override IEnumerable<Constraint> SplitToPrimitives(Solver sudokuSolver)
+    {
+        List<WhispersConstraint> constraints = new(cells.Count - 1);
+        for (int i = 0; i < cells.Count - 1; i++)
+        {
+            List<(int, int)> cellsPair = new() { cells[i], cells[i + 1] };
+            cellsPair.Sort();
+            constraints.Add(new(sudokuSolver, cellsPair, difference));
+        }
+        return constraints;
     }
 }
 

--- a/SudokuSolver/Solver.cs
+++ b/SudokuSolver/Solver.cs
@@ -4415,7 +4415,7 @@ public class Solver
             {
                 result.Add(name, new());
             }
-            result[name].Add(constraint.GetHash(this), constraint);
+            result[name].TryAdd(constraint.GetHash(this), constraint);
         }
 
         customInfo.Add("constraintsIndex", result);

--- a/SudokuSolver/Solver.cs
+++ b/SudokuSolver/Solver.cs
@@ -4408,7 +4408,7 @@ public class Solver
 
         Dictionary<string, Dictionary<string, Constraint>> result = new();
 
-        foreach (Constraint constraint in constraints)
+        foreach (Constraint constraint in constraints.SelectMany(constraint => constraint.SplitToPrimitives(this)))
         {
             string name = constraint.Name;
             if (!result.ContainsKey(name))

--- a/SudokuSolver/SolverUtility.cs
+++ b/SudokuSolver/SolverUtility.cs
@@ -87,7 +87,7 @@ public static class SolverUtility
     public static bool IsDiagonal(int i0, int j0, int i1, int j1) => (i0 == i1 - 1 || i0 == i1 + 1) && (j0 == j1 - 1 || j0 == j1 + 1);
     public static string CellName((int, int) cell) => $"r{cell.Item1 + 1}c{cell.Item2 + 1}";
     public static string CellName(int i, int j) => CellName((i, j));
-    public static string CellNames(this IEnumerable<(int, int)> cells) => string.Join(", ", cells.Select(CellName));
+    public static string CellNames(this IEnumerable<(int, int)> cells, string separator = ", ") => string.Join(separator, cells.Select(CellName));
 
     public static int BinomialCoeff(int n, int k)
     {

--- a/SudokuTests/Puzzles.cs
+++ b/SudokuTests/Puzzles.cs
@@ -591,6 +591,143 @@ internal static class Puzzles
             // Adding black dots affects the anti-ratio area
             false
         ),
+        (
+            "add a white dot to non-consecutive and white dots",
+            // A puzzle with 1 white dot and non-consecutive
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsA9uIDG0sDBkBXAC4QAbnHgqMSmKmwQAZkZgYYsrYRAyYAGzth8IAEoAmAMJuQqFwEYvEGoaIiA=",
+            // Add a white dot to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsA9uIDG0sDBkBXAC4QAbnHgqMSmKmwQAZkZgYYsrYRAyYAGzth8IAEoAmAMJuQqFwEYvEGoKG3tHZxcAZg8AVh9XABZYoJoiIA==",
+            // Adding white dots affects the non-consecutive area
+            false
+        ),
+        (
+            "add a black dot to anti-ratio and black dots",
+            // A puzzle with 1 black dot and anti-ratio
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAxyIAexBj187StABjGABtTYfCABKAFgDCAJhCo79gIw6aRIA",
+            // Add a black dot to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAxyIAexBj187StABjGABtTYfCABKAFgDCAJhCo79gIw6KIE+csqbR3tEF0D7AFYvaiIgA===",
+            // Adding black dots affects the anti-ratio area
+            false
+        ),
+        (
+            "add negative constraints to regular kropki puzzle",
+            // A puzzle with kropki dots with no negative constraints
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0Q2CADNNMDDAB2AYzjxCIYwBsLYfCABKAVgDCAJhCo7ANlchaFczBWNqb2AMxODu5hTgAsvv6W1raOTgDsUXYxafGkAUHJLk4AHBnhJX65icF49qlOiBl15QmBSSF2RdkeiNkVoFXJnaGNTsN9eW01XhEZ3nHjA+2Fbh7hbn5qGACGAC4QAPb4/a3V9p2RHp3zLfnt3p6zvTeT9llxHlmRCyfJzgCMGSyAO+tymf1iGXBY2epzs4XSHkK6RBLxSDQ+9Ryx1BtWKGU6zUqP3anQBlx8GyIQA==",
+            // Add non-consecutive and anti-ratio to the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QAOwD26gMbawMHQFcALhABuceCYxGYqbBABmTmBhi6rhEDpgAbPzB8EAAlAFYAYQAmEFQQgDZokFoKH39A4JCAZgiw2NCcgBZk1N8AoPg8UMiAdnyQwoi6lNI08syoiIAOepyeltAyjMrQmojEerH+0vSKqpCupvrEJYG24fnFrMmI7bWhudDEvLjE4v3ZjqS4nJiUtXUYNABDM0tgjFeITWTUT7MfpVBpcRgtcvVFucZu1QYl4vVEs1oRtQo1inFGnkLjD5pEAIz1RoE7EokJ4iLo0LkvbIw7ZJZxTpI1oHTKRCYY8YlFkg+ZTCHdbnAnGhRYEuKLO5EFJAA===",
+            // Adding negative constraints only restricts the solution
+            true
+        ),
+        (
+            "remove non-consecutive from a kropki puzzle",
+            // A puzzle with kropki dots with non-consecutive and anti-ratio
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QAOwD26gMbawMHQFcALhABuceCYxGYqbBABmTmBhi6rhEDpgAbPzB8EAAlAFYAYQAmEFQQgDZokFoKH39A4JCAZgiw2NCcgBZk1N8AoPg8UMiAdnyQwoi6lNI08syoiIAOepyeltAyjMrQmojEerH+0vSKqpCupvrEJYG24fnFrMmI7bWhudDEvLjE4v3ZjqS4nJiUtXUYNABDM0tgjFeITWTUT7MfpVBpcRgtcvVFucZu1QYl4vVEs1oRtQo1inFGnkLjD5pEAIz1RoE7EokJ4iLo0LkvbIw7ZJZxTpI1oHTKRCYY8YlFkg+ZTCHdbnAnGhRYEuKLO5EFJAA===",
+            // Remove non-consecutive from the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0Q2CADNNMDDAB2AYzjxCIYwBsLYfCABKAVgDCAJhCo7ANlchaFczBWNqb2AMxODu5hTgAsvv6W1raOTgDsUXYxafGkAUHJLk4AHBnhJX65icF49qlOiBl15QmBSSF2RdkeiNkVoFXJnaGNTsN9eW01XhEZ3nHjA+2Fbh7hbn5q+jBoAIYALhAAbiY1GPsQAPa+qGcHV6b9rdX2nZEenfMt+e3enrO9X0m9iycQ8WUiCyeyWcAEYMlk4ZDvlMYbEMqixoDnnZwukPIV0kigSkGmD6jlHsjasUMp1mpUoe1OnD3j4NkQgA=",
+            // Removing negative constraint may lead to additional solutions
+            false
+        ),
+        (
+            "remove anti-ratio from a kropki puzzle",
+            // A puzzle with kropki dots with non-consecutive and anti-ratio
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QAOwD26gMbawMHQFcALhABuceCYxGYqbBABmTmBhi6rhEDpgAbPzB8EAAlAFYAYQAmEFQQgDZokFoKH39A4JCAZgiw2NCcgBZk1N8AoPg8UMiAdnyQwoi6lNI08syoiIAOepyeltAyjMrQmojEerH+0vSKqpCupvrEJYG24fnFrMmI7bWhudDEvLjE4v3ZjqS4nJiUtXUYNABDM0tgjFeITWTUT7MfpVBpcRgtcvVFucZu1QYl4vVEs1oRtQo1inFGnkLjD5pEAIz1RoE7EokJ4iLo0LkvbIw7ZJZxTpI1oHTKRCYY8YlFkg+ZTCHdbnAnGhRYEuKLO5EFJAA===",
+            // Remove anti-ratio from the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QAOwD26gMbawMHQFcALhABuceCYxGYqbBABmTmBhi6rhEDpgAbPzB8EAAlAFYAYQAmEFQQgDZokFoKH39A4JCAZgiw2NCcgBZk1N8AoPg8UMiAdnyQwoi6lNI08syoiIAOepyeltAyjMrQmojEerH+0vSKqpCupvrEJYG24fnFrMmI7bWhudDEvLjE4v3ZjqS4nJiUtQwAQzNNfEHLkYXc+sXzmfbPol4vVEs1/htQo1inFGnkLgD5pEAIz1Roo+EQkJIiLQ0LYvbgw7ZJZxTpg1oHTKRCYw8YlCkfeZTH7denvBGhRYouKLO5EFJAA=",
+            // Removing negative constraint may lead to additional solutions
+            false
+        ),
+        (
+            "add more kropki dots to regular kropki puzzle",
+            // A puzzle with kropki dots with no negative constraints
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0Q2CADNNMDDAB2AYzjxCIYwBsLYfCABKAVgDCAJhCo7ANlchaFczBWNqb2AMxODu5hTgAsvv6W1raOTgDsUXYxafGkAUHJLk4AHBnhJX65icF49qlOiBl15QmBSSF2RdkeiNkVoFXJnaGNTsN9eW01XhEZ3nHjA+2Fbh7hbn5qGACGAC4QAPb4/a3V9p2RHp3zLfnt3p6zvTeT9llxHlmRCyfJzgCMGSyAO+tymf1iGXBY2epzs4XSHkK6RBLxSDQ+9Ryx1BtWKGU6zUqP3anQBlx8GyIQA==",
+            // Add one black kropki and one white kropki to the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0Q2CADNNMDDAB2AYzjxCIYwBsLYfCABKAVgDCAJhCo7ANlchaFczBWNqb2AMxODu5hTgAsvv6W1raOTgDsUXYxafGkAUHJLk4AHBnhJX65icF49qlOiBl15QmBSSF2RdkeiNkVoFXJnaGNTsN9eW01XhEZ3nHjA+2Fbh7hbgut1bVOniORfmoYAIYALhAA9vj9m4MzHp3zLfnt3rse3ukbz1NZcR5Z+yek3szgAjBksuCvsC7KDYhk4WMgVs7OF0h5Cp9kclnA1/vUctdvtsSvdioSJijOuCyetsUsdhlCoC/EA==",
+            // Adding more dots only restricts the solution if there are no negative constraints
+            true
+        ),
+        #endregion
+        #region XV and negative constraints
+        (
+            "add a V to no XV",
+            // Empty 6x6
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cW1IkA",
+            // 6x6 with a V
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAZgDCAJhCo1AFl0gxkgIYKArnHggAaiBpEgA=",
+            // Adding new constraints only restricts the solution if it doesn't affect negative constraints
+            true
+        ),
+        (
+            "add a V to a XV puzzle",
+            // A puzzle with 1 X and 1 V
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAZgDCAJhCo1AFl0gxkgIYKArnHggAaiAoh5SlfDzrtG/V5NnLGwQQAA0naiIgA===",
+            // Add a V to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAZgDCAJhCo1AFl0gxkgIYKArnHggAaiAoh5SlfDzrtG/V5NnLGwQQAA0nUhdFZVU1RC1DX1itAFZTVAtrWwcnaiIgA===",
+            // Adding new constraints only restricts the solution if it doesn't affect negative constraints
+            true
+        ),
+        (
+            "add a X to a XV puzzle",
+            // A puzzle with 1 X and 1 V
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAZgDCAJhCo1AFl0gxkgIYKArnHggAaiAoh5SlfDzrtG/V5NnLGwQQAA0naiIgA===",
+            // Add an X to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAZgDCAJhCo1AFl0gxkgIYKArnHggAaiAoh5SlfDzrtG/V5NnLGwQQAA0nUhdFZVU1AFYtWN81RATTVAtrW1CnaiIgA===",
+            // Adding new constraints only restricts the solution if it doesn't affect negative constraints
+            true
+        ),
+        (
+            "add a V to an empty anti-XV",
+            // Empty 6x6 with anti-XV
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35qRIA===",
+            // 6x6 with anti-XV and a V
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgBYAwgGYQqc7btbUC6YYCuykADUQNERAA",
+            // Adding V affects the anti-XV area
+            false
+        ),
+        (
+            "add an X to an empty anti-XV",
+            // Empty 6x6 with anti-XV
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35qRIA===",
+            // 6x6 with anti-XV and an X
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEBoiIA===",
+            // Adding X affects the anti-XV area
+            false
+        ),
+        (
+            "add a V to anti-XV with existing XVs",
+            // A puzzle with 1 X, 1 V and anti-XV
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEAoQA2NTFQtba0sHCOsnNxAPb18ANUDqIiA==",
+            // Add a V to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEAoQA2NTFQtba0sHCOsnNxAPb18ANUDSYKMTM2drAEYYq3yEpJ8EEDSaIiA==",
+            // Adding V affects the anti-ratio area
+            false
+        ),
+        (
+            "add an X to anti-XV with existing XVs",
+            // A puzzle with 1 X, 1 V and anti-XV
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEAoQA2NTFQtba0sHCOsnNxAPb18ANUDqIiA==",
+            // Add an X to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEAoQA2NTFQtba0sHCOsnNxAPb18ANUDSYKMTM3MAFmtcmLy4hKSfBH9A6iIgA",
+            // Adding X affects the anti-ratio area
+            false
+        ),
+        (
+            "add anti-XV to regular XV puzzle",
+            // A puzzle with XV with no negative constraints
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAJgDCAVhCo1AZl0gxkgIYKArnHggAGiAoh5SlfDzqdWjfq9bDU1QLa1sQADUnaiIgA===",
+            // Add anti-XV to the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEAoQA2NTFQtba0sHCOsnNxAPb18ANUDqIiA==",
+            // Adding negative constraints only restricts the solution
+            true
+        ),
+        (
+            "remove anti-XV from an XV puzzle",
+            // A puzzle with 1 X, 1 V and anti-XV
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEADsYaAIYAXCADc48PCAAeCkGI35QAYxgAbQ2HwgASgCYAwgFYQqcwGY7W1AumGArspAANEAoQA2NTFQtba0sHCOsnNxAPb18ANUDqIiA==",
+            // Remove anti-XV from the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAA8AbvlABjGABsFYfCABKAJgDCAVhCo1AZl0gxkgIYKArnHggAGiAoh5SlfDzqdWjfq9bDU1QLa1sQADUnaiIgA===",
+            // Removing negative constraint may lead to additional solutions
+            false
+        ),
         #endregion
         #endregion
     };

--- a/SudokuTests/Puzzles.cs
+++ b/SudokuTests/Puzzles.cs
@@ -491,6 +491,15 @@ internal static class Puzzles
             // Updating constraint options may lead to different puzzle solutions
             false
         ),
+        (
+            "duplicate the same constraint",
+            // A puzzle with a renban
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEBhgA7AEYBDSflAAbCJJhh8eEACUALAGEAzCFTbD+3SZ0AmfQFYQ1ajVQq1ikG/WadB46fNLU1sHJ1QAewBXABcvfQQQAGIAMQAGRAB2NKsAdxxogAsEVIA6XVQAMwxwgFt9cMkwaIxZVWiE7Sk5BRoiIA=",
+            // Add the same renban to the puzzle above one more time (so that the contraint is duplicated)
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEBhgA7AEYBDSflAAbCJJhh8eEACUALAGEAzCFTbD+3SZ0AmfQFYQ1ahRAq1G+AR0Hjp85dNbBycaVDc4T2VVdU1vIyszCwSgxzEAewBXABdw/QQQAGIAMQAGRAB2UqsAdxwsgAsEEoA6XVQAMww0gFt9NMkwLIxZVSz87Sk5BRdwjy89eL8kwPtU1Eyc6Lz4QtKKqtRa7Aam1o6u3v7B4dHxyfkQGiIgA==",
+            // Duplicating constraints doesn't affect the solution
+            true
+        ),
         #region Kropki dots and negative constraints
         (
             "add a white dot to no black dots",

--- a/SudokuTests/Puzzles.cs
+++ b/SudokuTests/Puzzles.cs
@@ -729,6 +729,192 @@ internal static class Puzzles
             false
         ),
         #endregion
+        #region Whispers
+        (
+            "add a line segment to whispers",
+            // A puzzle with whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ZDVqNVGs3KQnrfjz6xmYW1nYWjs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZ9uI48ZIIOQB0NqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Add 1 more line segment to whispers line in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ft6TRgyGrUaqNZuUgflr4ePrGZhbWdhaOzhZuHl6oAPYArgAuQUYIIADEiADsAGIADIX24jjpkgglAHQ2qABmGMkAtkbJ6mDpGACGGuk5AOrScgpKNERAA===",
+            // Adding a new segment to existing whispers line is identical to adding a separate whispers line
+            true
+        ),
+        (
+            "remove a line segment from whispers",
+            // A puzzle with whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ft6TRgyGrUaqNZuUgflr4ePrGZhbWdhaOzhZuHl6oAPYArgAuQUYIIADEiADsAGIADIX24jjpkgglAHQ2qABmGMkAtkbJ6mDpGACGGuk5AOrScgpKNERAA===",
+            // Remove 1 line segment from whispers line in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ZDVqNVGs3KQnrfjz6xmYW1nYWjs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZ9uI48ZIIOQB0NqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Removing existing whispers line segments may lead to different puzzle solutions
+            false
+        ),
+        (
+            "replace a line segment in whispers",
+            // A puzzle with whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ZDVqNVGs3KQnrfjz6xmYW1nYWjs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZ9uI48ZIIOQB0NqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Replace 1 whispers line segment by a different line segment in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9N2yGrUaqNZuUgPW/Hn3GZhbWdhaOdi6oAPYArgAuPkYIIADEiADsAGIADBn24jhxkgjZAHQ2qABmGFEAtkZR6mBxGACGGnHJAOrScgpKNERAA===",
+            // Removing existing whispers line segments may lead to different puzzle solutions
+            false
+        ),
+        (
+            "invert whispers direction",
+            // A puzzle with whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ZDVqNVGs3KQnrfjz6xmYW1nYWjs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZ9uI48ZIIOQB0NqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Replace whispers line in the puzzle above by the same line, but backwards
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQDMAYQAsIVHpNGD5/QFYjAJhDVqNVGs3KQnrfjz6xmYWVjYWDs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZtuI48ZIIOQB0BqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Changing whispers line direction doesn't affect the puzzle
+            true
+        ),
+        (
+            "split whispers line",
+            // A puzzle with whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ZDVqNVGs3KQnrfjz6xmYW1nYWjs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZ9uI48ZIIOQB0NqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Split whispers line in the puzzle above into 2 segments
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMwhq1CiDWbtuvTaOXz+63Yc0qC5wOqoaWvh4+sZmFn72YgD2AK4ALsFGCCAAxIgA7ABiAAz5PuI4qZIIRQB0NqgAZhiJALZGiepgqRgAhhqpWQDq0nIKSk7BblEeXj5WtgmoKenhmfA5+cWlqOXYldV1jc1tHV29/UMj8oogNERAA===",
+            // Multiple segments of a whispers line are identical to 1 whispers line made of them
+            true
+        ),
+        (
+            "duplicated whispers line segments",
+            // A puzzle with whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCsAYQBMIVHoAsRgMzn9No5ZDVqNVGs3KQnrfjz6xmYW1nYWjs6uqAD2AK4ALr5GCCAAxIgA7ABiAAyZ9uI48ZIIOQB0NqgAZhjRALZG0epg8RgAhhrxKQDq0nIKSjREQA==",
+            // Add a new whispers line to the puzzle above that is a subset of the existing whispers line
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQDMAYQAsIVHpNGDIatQog1m7br0BWIwCZz+qzYvGZnY0qE5wOqoaWvh4+oE+lta2YgD2AK4ALmFGCCAAxIgA7ABiAAxFPuI4GZIIpQB0BqgAZhgpALZGKepgGRgAhhoZuQDq0nIKSg5hLrHuXgl+CfF2qOlZUTnw+UVlFahV2DV1jS1tnd29A0Oj4/KKIDREQA==",
+            // Duplicating whisper line segments doesn't affect the puzzle
+            true
+        ),
+        (
+            "different whispers line in the same cells",
+            // A puzzle with whispers line (R2C1->R1C1->R1C2)
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQBMAYQCMIVHpOnz+qwZDVqNVGs3KQrrfjz7jZi1b+tkb2jqgA9gCuAC6eRgggAMSIAOwAYgAMqTbiONGSCBkAdADMqABmGOEAtkbh6mDRGACGGtEJAOrScgpKNERAA==",
+            // Replace whispers line in the puzzle above with a different whispers line that takes the same cells (R1C1->R1C2->R2C1)
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAHcAFhDAAHGBjD5QAGwgA7GEvgEQAJQCMAYQMhUhowCYz+yyZDVqNVGs3KQrrfjz7jp88bW5namjqgA9gCuAC6eRgggAMSIAOwAYgAMqTbiONGSCBkAdADMqABmGOEAtkbh6mDRGACGGtEJAOrScgpKNERAA==",
+            // The whispers line is defined by its line segments, not by its cells
+            false
+        ),
+        #endregion
+        #region Entropic lines
+        (
+            "add a line segment to entropic line",
+            // A puzzle with entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFEgtLREaraW1qn2Vo6+Xj7uAXnxPpHRznGhiai6AK5aqW4IIADEAGItbm4Agp2BAO44WgAWCAAMAHQeAKyoAGZ6ALZuuhpgOgCG5lqNAKLaeoZGAAQAMuZwyURAA===",
+            // Add 1 more line segment to entropic line in the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFFhcQCsILS0RGq2ltaZ9laOvl4+7gFF8T6R0c5xlU5JKWq6AK5amW4IIADEAGJdbm4Agv2BAO44WgAWCAAMAHQeiagAZnoAtm66GmA6AIbmWu0Aotp6hkYABAAy5nDpREA=",
+            // Adding a new segment to existing entropic line is identical to adding a separate entropic line
+            true
+        ),
+        (
+            "remove a line segment from entropic line",
+            // A puzzle with entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFFhcQCsILS0RGq2ltaZ9laOvl4+7gFF8T6R0c5xlU5JKWq6AK5amW4IIADEAGJdbm4Agv2BAO44WgAWCAAMAHQeiagAZnoAtm66GmA6AIbmWu0Aotp6hkYABAAy5nDpREA=",
+            // Remove 1 line segment from entropic line in the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFEgtLREaraW1qn2Vo6+Xj7uAXnxPpHRznGhiai6AK5aqW4IIADEAGItbm4Agp2BAO44WgAWCAAMAHQeAKyoAGZ6ALZuuhpgOgCG5lqNAKLaeoZGAAQAMuZwyURAA===",
+            // Removing existing entropic line segments may lead to different puzzle solutions
+            false
+        ),
+        (
+            "replace a line segment in entropic line",
+            // A puzzle with entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFEgtLREaraW1qn2Vo6+Xj7uAXnxPpHRznGhiai6AK5aqW4IIADEAGItbm4Agp2BAO44WgAWCAAMAHQeAKyoAGZ6ALZuuhpgOgCG5lqNAKLaeoZGAAQAMuZwyURAA===",
+            // Replace 1 entropic line segment by a different line segment in the puzzle above
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT6RAKwgtLREaraW1qn2Vo6+Xj7uAXlRYZHRznEJaroArlqpbgggAMQAYs1ubgCCHYEA7jhaABYIAAwAdB6xqABmegC2broaYDoAhuZaDQCi2nqGRgAEADLmcMlEQA==",
+            // Removing existing entropic line segments may lead to different puzzle solutions
+            false
+        ),
+        (
+            "invert entropic direction",
+            // A puzzle with entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFEgtLREaraW1qn2Vo6+Xj7uAXnxPpHRznGhiai6AK5aqW4IIADEAGItbm4Agp2BAO44WgAWCAAMAHQeAKyoAGZ6ALZuuhpgOgCG5lqNAKLaeoZGAAQAMuZwyURAA===",
+            // Replace entropic line in the puzzle above by the same line, but backwards
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKANgDCAFhConAdk/ezgAcAT4hAMyBTiEATCC0tERqtpbWKfZWjq6hzv5eYTnRbpEFcQmougCuWiluCCAAxABiTW5uAILtgQDuOFoAFggADAB0MQCsqABmegC2broaYDoAhuZa9QCi2nqGRgAEADLmcElEQA==",
+            // Changing entropic line direction doesn't affect the puzzle
+            true
+        ),
+        (
+            "split entropic line",
+            // A puzzle with entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFEgtLREaraW1qn2Vo6+Xj7uAXnxPpHRznGhiai6AK5aqW4IIADEAGItbm4Agp2BAO44WgAWCAAMAHQeAKyoAGZ6ALZuuhpgOgCG5lqNAKLaeoZGAAQAMuZwyURAA===",
+            // Split entropic line in the puzzle above into 2 segments
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALCC0tBQ25jD2Vo6+oT4A7G6JzgBsqWERaraW1nmxBEGegb4BPiHZqLoArlp5bgggAMQAYm1ubgCC3YEA7jhaABYIAAwAdB4ArKgAZnoAtm66GmA6AIbmWs0Aotp6hkYABAAy0SCRhQ4laU4pd5mh4TX1jc3tnT19qIPYI+MprMQAtdMtVusMFttHsDgZjGcLkQIkA===",
+            // Multiple segments of a entropic line are not identical to 1 entropic line made of them because the direction of entropy alternation may be reversed in the connection point
+            false
+        ),
+        (
+            "duplicated entropic line segments",
+            // A puzzle with entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAJhCpXbgMzezu4ALIFOAOxuoT4AbFEgtLREaraW1qn2Vo6+Xj7uAXnxPpHRznGhiai6AK5aqW4IIADEAGItbm4Agp2BAO44WgAWCAAMAHQeAKyoAGZ6ALZuuhpgOgCG5lqNAKLaeoZGAAQAMuZwyURAA===",
+            // Add a new entropic line to the puzzle above that is a subset of the existing entropic line
+            @"N4IgzglgXgpiBcBOANCA5gJwgEwQbT2AF9ljSSzKLryBdZQmq8l54+x1p7rjtn/nQaCR3PgIm9hk0UM6zR4rssX0QMAHYAXDAHsADhADGAGwga48QiDMWw+PCABKADgDCAFhConAdk/ezgBsAbS0FDbmMPZWjq5uAEyB8QDMye5ePv6ZwaHharaW1oUxBM4ZydnJIV5hqLoArlqFbgggAMQAYp1ubgCCfYEA7jhaABYIAAwAdAkArKgAZnoAtm66GmA6AIbmWm0Aotp6hkYABAAyUSARJQ7lieluaT4VWQE+NSB1II3NUa14B1ur0BsNRhN4DN5ktVutNjs9odjgZjJdrkRwkA==",
+            // Duplicating whisper line segments doesn't affect the puzzle
+            true
+        ),
+        #endregion
+        #region Thermometers
+        (
+            "add a line segment to thermometer",
+            // A puzzle with thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNkNWo0iQA=",
+            // Add 1 more line segment to thermometer in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNp4fOnjIatRpEgA===",
+            // Adding a new segment to existing thermometer can only restrict the puzzle solutions
+            true
+        ),
+        (
+            "remove a line segment from thermometer",
+            // A puzzle with thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNp4fOnjIatRpEgA===",
+            // Remove 1 line segment from thermometer in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNkNWo0iQA=",
+            // Removing existing thermometer segments may lead to different puzzle solutions
+            false
+        ),
+        (
+            "replace a line segment in thermometer",
+            // A puzzle with thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNkNWo0iQA=",
+            // Replace 1 thermometer segment by a different line segment in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP2HIatRpEgA==",
+            // Removing existing thermometer segments may lead to different puzzle solutions
+            false
+        ),
+        (
+            "invert thermometer direction",
+            // A puzzle with thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNkNWo0iQA=",
+            // Replace thermometer in the puzzle above by the same thermometer, but backwards
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAMwBhACwhUh86eNWjAVlMAmENWo0iQA=",
+            // Changing will lead to another puzzle solution
+            false
+        ),
+        (
+            "split thermometer",
+            // A puzzle with thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNkNWo0iQA=",
+            // Split thermometer in the puzzle above into 2 thermometer segments
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlACwBhAMwhUh86eMhq1CiE0698AkYCspgExWjM0tHGiIgA===",
+            // Multiple segments of a thermometer are identical to 1 thermometer made of them
+            true
+        ),
+        (
+            "duplicated thermometer segments",
+            // A puzzle with thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAKwBhAEwhUhgCymAzFaP3TNkNWo0iQA=",
+            // Add a new thermometer to the puzzle above that is a subset of the existing thermometer
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlACwBhAMwhUh86eMhq1CiE0698AkYCspgExWjM0trW3tHGiIgA===",
+            // Duplicating thermometer segments doesn't affect the puzzle
+            true
+        ),
+        (
+            "different thermometer in the same cells",
+            // A puzzle with thermometer (R2C1->R1C1->R1C2)
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAEwBhAIwhUh8xatHbxkNWo0iQA==",
+            // Replace thermometer in the puzzle above with a different thermometer that takes the same cells (R1C1->R1C2->R2C1)
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEABcAFjAwBbAPayY4mflAAbCADsYYfHhAAlAIwBhYyFQnTAJktGb5kNWo0iQA==",
+            // The thermometer is defined by its line segments, not by its cells
+            false
+        ),
+        #endregion
         #endregion
     };
 }

--- a/SudokuTests/Puzzles.cs
+++ b/SudokuTests/Puzzles.cs
@@ -915,6 +915,35 @@ internal static class Puzzles
             false
         ),
         #endregion
+        #region Killer cages
+        (
+            "add killer cage sum",
+            // A puzzle with a clueless killer cage
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAGsIAGykwMAYwCGaOPEIh5MGWHwgASgGYAwgZCo9AFhNn9ViyGo0iQA===",
+            // Add a clue to the killer cage in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAGsIAGykwMAYwCGaOPEIh5MGWHwgASgGYAwgZCo9AFhNn9ViyDEA3RVICuqkAEYADCBpEgA===",
+            // Adding a sum clue to a clueless cage can only restrict the puzzle solution
+            true
+        ),
+        (
+            "remove killer cage sum",
+            // A puzzle with a killer cage with a clue
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAGsIAGykwMAYwCGaOPEIh5MGWHwgASgGYAwgZCo9AFhNn9ViyDEA3RVICuqkAEYADCBpEgA===",
+            // Remove the clue from the killer cage in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAGsIAGykwMAYwCGaOPEIh5MGWHwgASgGYAwgZCo9AFhNn9ViyGo0iQA===",
+            // Removing killer cage clue may lead to other puzzle solutions
+            false
+        ),
+        (
+            "change killer cage sum",
+            // A puzzle with a killer cage with a clue
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAGsIAGykwMAYwCGaOPEIh5MGWHwgASgGYAwgZCo9AFhNn9ViyDEA3RVICuqkAEYADCBpEgA===",
+            // Replace the clue in the killer cage by a different value in the puzzle above
+            @"N4IgzglgXgpiBcA2ANCA5gJwgEwQbT2AF9ljSSzKiBdZQih8p42+5xq1q99rj/8nx7cWtEAGsIAGykwMAYwCGaOPEIh5MGWHwgASgGYAwgZCo9AFhNn9ViyDEA3RVICuqkAEYATCBpEgA===",
+            // Replacing killer cage clue will lead to other puzzle solutions
+            false
+        ),
+        #endregion
         #endregion
     };
 }


### PR DESCRIPTION
Optimize `Solver.IsInheritOf` by splitting composite constraints into primitive constraint objects:
- Split kropki dots and XV into individual markers and negative constraints (while respecting negative constraint area overrides).
- Split whispers, entropic lines and thermometers into smaller lines.
- Split killer cages into cell uniqueness groups and cells sums (so that adding sum to a clueless cage will re-use previous "true candidates" results).

Includes changes from #105 