### PR TITLE
Fix NullReferenceException in OrthogonalValueConstraint

### DIFF
--- a/SudokuSolver/Constraints/DifferenceConstraint.cs
+++ b/SudokuSolver/Constraints/DifferenceConstraint.cs
@@ -15,6 +15,16 @@ public class DifferenceConstraint : OrthogonalValueConstraint
     {
     }
 
+    protected override OrthogonalValueConstraint createNegativeConstraint(Solver sudokuSolver, int negativeConstraintValue)
+    {
+        return new DifferenceConstraint(sudokuSolver, negativeConstraintValue);
+    }
+
+    protected override OrthogonalValueConstraint createMarkerConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2)
+    {
+        return new DifferenceConstraint(sudokuSolver, markerValue, cell1, cell2);
+    }
+
     protected override bool IsPairAllowedAcrossMarker(int markerValue, int v0, int v1) => (v0 + markerValue == v1 || v1 + markerValue == v0);
 
     protected override IEnumerable<OrthogonalValueConstraint> GetRelatedConstraints(Solver solver) =>

--- a/SudokuSolver/Constraints/OrthogonalValueConstraint.cs
+++ b/SudokuSolver/Constraints/OrthogonalValueConstraint.cs
@@ -154,6 +154,9 @@ public abstract class OrthogonalValueConstraint : Constraint
         initClearValuesPositiveByMarker(new int[] { markerValue });
     }
 
+    protected abstract OrthogonalValueConstraint createNegativeConstraint(Solver sudokuSolver, int negativeConstraintValue);
+    protected abstract OrthogonalValueConstraint createMarkerConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2);
+
     private uint[] initClearValuesNegative()
     {
         var clearValuesNegative = new uint[MAX_VALUE];
@@ -674,20 +677,17 @@ public abstract class OrthogonalValueConstraint : Constraint
     {
         // Return the list of each marker and each negative constraint as an individual constraint object
 
-        var type = GetType();
-        var markerConstructor = type.GetConstructor(new Type[] { typeof(Solver), typeof(int), typeof((int, int)), typeof((int, int)) });
-        var constraints = markers.Select(marker => (Constraint)markerConstructor.Invoke(new object[] {
+        var constraints = markers.Select(marker => createMarkerConstraint(
             sudokuSolver,
             marker.Value,
             (marker.Key.Item1, marker.Key.Item2),
-            (marker.Key.Item3, marker.Key.Item4),
-        }));
+            (marker.Key.Item3, marker.Key.Item4)
+        ));
 
         if (negativeConstraint)
         {
-            var negativeConstraintConstructor = type.GetConstructor(new Type[] { typeof(Solver), typeof(int) });
             constraints = constraints.Concat(negativeConstraintValues.Select(
-                value => (Constraint)negativeConstraintConstructor.Invoke(new object[] { sudokuSolver, value })
+                value => createNegativeConstraint(sudokuSolver, value)
             ));
         }
 

--- a/SudokuSolver/Constraints/RatioConstraint.cs
+++ b/SudokuSolver/Constraints/RatioConstraint.cs
@@ -15,6 +15,16 @@ public class RatioConstraint : OrthogonalValueConstraint
     {
     }
 
+    protected override OrthogonalValueConstraint createNegativeConstraint(Solver sudokuSolver, int negativeConstraintValue)
+    {
+        return new RatioConstraint(sudokuSolver, negativeConstraintValue);
+    }
+
+    protected override OrthogonalValueConstraint createMarkerConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2)
+    {
+        return new RatioConstraint(sudokuSolver, markerValue, cell1, cell2);
+    }
+
     protected override bool IsPairAllowedAcrossMarker(int markerValue, int v0, int v1) => (v0 * markerValue == v1 || v1 * markerValue == v0);
 
     protected override IEnumerable<OrthogonalValueConstraint> GetRelatedConstraints(Solver solver) =>

--- a/SudokuSolver/Constraints/SumConstraint.cs
+++ b/SudokuSolver/Constraints/SumConstraint.cs
@@ -15,6 +15,16 @@ public class SumConstraint : OrthogonalValueConstraint
     {
     }
 
+    protected override OrthogonalValueConstraint createNegativeConstraint(Solver sudokuSolver, int negativeConstraintValue)
+    {
+        return new SumConstraint(sudokuSolver, negativeConstraintValue);
+    }
+
+    protected override OrthogonalValueConstraint createMarkerConstraint(Solver sudokuSolver, int markerValue, (int, int) cell1, (int, int) cell2)
+    {
+        return new SumConstraint(sudokuSolver, markerValue, cell1, cell2);
+    }
+
     protected override bool IsPairAllowedAcrossMarker(int markerValue, int v0, int v1) => (v0 + v1 == markerValue);
 
     protected override int DefaultMarkerValue => 5;


### PR DESCRIPTION
Type reflection doesn't work in the final builds (despite working locally): `GetType().GetConstructor()` returns `null` in `OrthogonalValueConstraint.SplitToPrimitives`.
Fixed it by replacing reflection with abstract methods.