### PR TITLE
Console option to print unexpected exceptions

### DIFF
--- a/SudokuSolverConsole/Program.cs
+++ b/SudokuSolverConsole/Program.cs
@@ -49,6 +49,7 @@ class Program
 		port.DefaultValue = 4545;
         var listConstraints = app.Option("--list-constraints", "List all available constraints.", CommandOptionType.NoValue);
         var hideBanner = app.Option("--hide-banner", "Do not show the text with app version and support links.", CommandOptionType.NoValue);
+        var verbose = app.Option("--verbose", "Print verbose logs.", CommandOptionType.NoValue);
 
         app.OnExecuteAsync(async cancellationToken =>
 		{
@@ -76,6 +77,7 @@ class Program
 				Port = port.ParsedValue,
                 ListConstraints = listConstraints.HasValue(),
                 HideBanner = hideBanner.HasValue(),
+                VerboseLogs = verbose.HasValue(),
             };
 
             await program.OnExecuteAsync(app, cancellationToken);
@@ -117,6 +119,7 @@ class Program
 	// Help-related options
     public required bool ListConstraints { get; init; }
 	public required bool HideBanner { get; init; }
+    public required bool VerboseLogs { get; init; }
 
 	public async Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken = default)
 	{
@@ -170,7 +173,7 @@ class Program
 		if (Listen)
 		{
 			using WebsocketListener websocketListener = new();
-			await websocketListener.Listen("localhost", Port, Constraints);
+			await websocketListener.Listen("localhost", Port, Constraints, VerboseLogs);
 
 			Console.WriteLine("Press CTRL + Q to quit.");
 

--- a/SudokuSolverConsole/WebsocketListener.cs
+++ b/SudokuSolverConsole/WebsocketListener.cs
@@ -98,8 +98,9 @@ class WebsocketListener : IDisposable
     private readonly Dictionary<byte[], BaseResponse> trueCandidatesResponseCache = new(new ByteArrayComparer());
     private readonly List<ResponseCacheItem> lastTrueCandidatesResponses = new();
     private List<string> additionalConstraints;
+    private bool verboseLogs = false;
 
-    public async Task Listen(string host, int port, IEnumerable<string> additionalConstraints = null)
+    public async Task Listen(string host, int port, IEnumerable<string> additionalConstraints = null, bool verboseLogs = false)
     {
         if (server != null)
         {
@@ -107,6 +108,7 @@ class WebsocketListener : IDisposable
         }
 
         this.additionalConstraints = additionalConstraints?.ToList();
+        this.verboseLogs = verboseLogs;
 
         server = new(host, port, false);
         server.ClientConnected += (_, args) => ClientConnected(args);
@@ -214,6 +216,10 @@ class WebsocketListener : IDisposable
                     }
                 catch (Exception e)
                 {
+                    if (verboseLogs)
+                    {
+                        Console.WriteLine(e);
+                    }
                     SendMessage(ipPort, new InvalidResponse(message.nonce) { message = e.Message });
                 }
             }, cancellationToken);


### PR DESCRIPTION
Running the script with `--verbose` will print exceptions that happened in `WebsocketListener` to the console.
The flag could be re-used for other verbose log purposes in the future.