### PR TITLE
Fix indexer constraint placement regression

### DIFF
--- a/UserScripts/fpuzzles-newconstraints.js
+++ b/UserScripts/fpuzzles-newconstraints.js
@@ -1379,28 +1379,16 @@
 
         // Row Indexer
         window.rowindexer = function (cell) {
-            this.cells = [];
-            this.cell = null;
-
-            this.sortCells = function () {
-                this.cells = this.cells.filter((c) => c);
-                this.cells.sort((a, b) => a.i * size + a.j - (b.i * size + b.j));
-                this.cell = this.cells.length > 0 ? this.cells[0] : null;
-            };
+            this.cells = [cell];
 
             this.addCellToRegion = function (cell) {
-                if (cell) {
-                    this.cells = [cell];
-                } else {
-                    this.cells = [];
-                }
+                this.cells.push(cell);
                 this.sortCells();
             };
 
-            if (cell) {
-                this.cells = [cell];
-                this.sortCells();
-            }
+            this.sortCells = function () {
+                this.cells.sort((a, b) => a.i * size + a.j - (b.i * size + b.j));
+            };
         };
 
         // Column Indexer
@@ -1574,6 +1562,7 @@
                         if (toolPerCellIndex < toolOutsideIndex) toolOutsideIndex++;
                         toolConstraints.splice(++toolPerCellIndex, 0, info.name);
                      }
+                    if (!regionConstraints.includes(info.name)) regionConstraints.push(info.name);
                     // For 'cage' type like Indexers, they behave like perCellConstraints for placement
                     if (!perCellConstraints.includes(info.name)) perCellConstraints.push(info.name);
                 } else if (info.type === "outside") {

--- a/UserScripts/fpuzzles-newconstraints.js
+++ b/UserScripts/fpuzzles-newconstraints.js
@@ -1379,16 +1379,28 @@
 
         // Row Indexer
         window.rowindexer = function (cell) {
-            this.cells = [cell];
+            this.cells = [];
+            this.cell = null;
+
+            this.sortCells = function () {
+                this.cells = this.cells.filter((c) => c);
+                this.cells.sort((a, b) => a.i * size + a.j - (b.i * size + b.j));
+                this.cell = this.cells.length > 0 ? this.cells[0] : null;
+            };
 
             this.addCellToRegion = function (cell) {
-                this.cells.push(cell);
+                if (cell) {
+                    this.cells = [cell];
+                } else {
+                    this.cells = [];
+                }
                 this.sortCells();
             };
 
-            this.sortCells = function () {
-                this.cells.sort((a, b) => a.i * size + a.j - (b.i * size + b.j));
-            };
+            if (cell) {
+                this.cells = [cell];
+                this.sortCells();
+            }
         };
 
         // Column Indexer


### PR DESCRIPTION
## Summary
- keep row/column/box indexer instances synchronized with their anchor cell so f-puzzles can draw them
- guard against undefined cells when sorting indexer targets to avoid NaN placement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8bbc38378832e8cdc5709efacbfe0